### PR TITLE
Ryo

### DIFF
--- a/src/IIHEModuleMuon.cc
+++ b/src/IIHEModuleMuon.cc
@@ -209,6 +209,8 @@ void IIHEModuleMuon::beginJob(){
   setBranchType(kVectorInt) ;
   addBranch("mu_numberOfMatchedStations") ;
   addBranch("mu_numberOfValidPixelHits") ;
+  addBranch("mu_numberOfValidTrackerHits") ;
+  addBranch("mu_numberOfValidMuonHits") ;
   
   // TeV optimized values
   addBranch("mu_tevOptimized_charge", kVectorInt) ;
@@ -317,12 +319,19 @@ void IIHEModuleMuon::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     
     int numberOfMatchStations        = 0 ;
     int numberOfValidPixelHits       = 0 ;
+    int numberOfValidTrackerHits     = 0 ;
+    int numberOfValidMuonHits        = 0 ;
     
     numberOfMatchStations = muIt->numberOfMatchedStations() ;
-    if(isTrackerMuon) numberOfValidPixelHits = muIt->innerTrack()->hitPattern().numberOfValidPixelHits() ;
+    if(isTrackerMuon) {
+      numberOfValidPixelHits = muIt->innerTrack()->hitPattern().numberOfValidPixelHits() ;
+      numberOfValidTrackerHits = muIt->innerTrack()->hitPattern().trackerLayersWithMeasurement() ;
+    }
     
     store("mu_numberOfMatchedStations", numberOfMatchStations ) ;
     store("mu_numberOfValidPixelHits" , numberOfValidPixelHits) ;
+    store("mu_numberOfValidTrackerHits" , numberOfValidTrackerHits) ;
+    store("mu_numberOfValidMuonHits"    , numberOfValidMuonHits   ) ;
     
     globalTrackWrapper_->reset() ;
     outerTrackWrapper_ ->reset() ;

--- a/src/IIHEModuleMuon.cc
+++ b/src/IIHEModuleMuon.cc
@@ -327,6 +327,9 @@ void IIHEModuleMuon::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       numberOfValidPixelHits = muIt->innerTrack()->hitPattern().numberOfValidPixelHits() ;
       numberOfValidTrackerHits = muIt->innerTrack()->hitPattern().trackerLayersWithMeasurement() ;
     }
+    if (isGlobalMuon) {
+      numberOfValidMuonHits = muIt->globalTrack()->hitPattern().numberOfValidMuonHits() ;
+    }
     
     store("mu_numberOfMatchedStations", numberOfMatchStations ) ;
     store("mu_numberOfValidPixelHits" , numberOfValidPixelHits) ;


### PR DESCRIPTION
I have made a modification to add variables :
1) recoMu.globalTrack()->hitPattern().numberOfValidMuonHits()
2) recoMu.innerTrack()->hitPattern().trackerLayersWithMeasurement()
, which are used in muon::isTightMuon method, but were not there.
